### PR TITLE
Fix documentation for deprecated installLanguageServer

### DIFF
--- a/plugins/lsp/default.nix
+++ b/plugins/lsp/default.nix
@@ -19,7 +19,7 @@ in {
         serverName:
           mkRemovedOptionModule
           ["plugins" "lsp" "servers" serverName "installLanguageServer"]
-          "If you want to not install the language server package, set `plugins.lsp.servers.${serverName}.package` to `false`."
+          "If you want to not install the language server package, set `plugins.lsp.servers.${serverName}.package` to `null`."
       )
       [
         "astro"


### PR DESCRIPTION
`plugins.lsp.servers.${serverName}.package` should be `null` instead of `false`